### PR TITLE
修改几处关于 PascalCase 和 camelCase 的文字

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -74,8 +74,8 @@
 ## Naming 命名
 
   - **扩展名**: React模块使用 `.jsx` 扩展名.
-  - **文件名**: 文件名使用驼峰式. 如, `ReservationCard.jsx`.
-  - **引用命名**: React模块名使用驼峰式命名，实例使用骆驼式命名. eslint: [`react/jsx-pascal-case`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
+  - **文件名**: 文件名使用帕斯卡命名. 如, `ReservationCard.jsx`.
+  - **引用命名**: React模块名使用帕斯卡命名，实例使用骆驼式命名. eslint: [`react/jsx-pascal-case`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
 
     ```jsx
     // bad


### PR DESCRIPTION
- PascalCase 是帕斯卡命名
- camelCase 是驼峰式命名

有些文章也将 PascalCase 翻译为 大写驼峰式命名